### PR TITLE
feat: add hello from Clawww log to openclaw plugin

### DIFF
--- a/packages/plugins/notifier-openclaw/src/index.ts
+++ b/packages/plugins/notifier-openclaw/src/index.ts
@@ -109,6 +109,8 @@ function formatActionsLine(actions: NotifyAction[]): string {
 }
 
 export function create(config?: Record<string, unknown>): Notifier {
+  console.log('[notifier-openclaw] hello from Clawww');
+
   const url =
     (typeof config?.url === "string" ? config.url : undefined) ??
     "http://127.0.0.1:18789/hooks/agent";


### PR DESCRIPTION
## Summary
- Adds `console.log('[notifier-openclaw] hello from Clawww')` to the `create` function in the openclaw notifier plugin
- Closes #574

## Test plan
- [ ] Verify the log message appears when the openclaw notifier plugin is initialized