### PR TITLE
fix: ao status --json returns valid JSON when no sessions

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -215,6 +215,10 @@ export function registerStatus(program: Command): void {
       try {
         config = loadConfig();
       } catch {
+        if (opts.json) {
+          console.log(JSON.stringify({ sessions: [] }));
+          return;
+        }
         console.log(chalk.yellow("No config found. Run `ao init` first."));
         console.log(chalk.dim("Falling back to session discovery...\n"));
         await showFallbackStatus();
@@ -314,7 +318,8 @@ export function registerStatus(program: Command): void {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(jsonOutput, null, 2));
+        console.log(JSON.stringify({ sessions: jsonOutput }, null, 2));
+        return;
       } else {
         console.log(
           chalk.dim(


### PR DESCRIPTION
Closes #6

**Problem:** `ao status --json` outputs an ASCII table instead of valid JSON when no sessions exist.

**Fix:**
- When config is missing and `--json` is passed, return `{"sessions": []}` immediately instead of falling through to the table renderer
- Wrap the JSON output in `{"sessions": [...]}` instead of outputting a bare array
- Early return after JSON output to skip the summary footer