### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig — https://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false


### PR DESCRIPTION
Closes #9

Adds `.editorconfig` for consistent formatting across editors:
- 2-space indent for TS/JS/JSON/YAML
- 4-space indent for Markdown
- UTF-8 charset, LF line endings
- Trim trailing whitespace (except Markdown)
- Insert final newline