### PR TITLE
chore: add LICENSE file (MIT)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Composio, Inc.
+Copyright (c) 2024-present Composio Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- Updates the MIT LICENSE file at the repository root to use the correct copyright year (`2024-present`) and copyright holder name (`Composio Inc.`) as specified in issue #13
- The file previously existed with year `2025` and `Composio, Inc.` (with comma); this PR corrects both to match the requirements

Closes #13

## Test plan
- [x] LICENSE file exists at repo root
- [x] Contains valid MIT license text
- [x] Copyright year is `2024-present`
- [x] Copyright holder is `Composio Inc.`
- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (warnings only, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)