### PR TITLE
feat: add --quiet flag to ao status for scriptable output

### DIFF
--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -830,4 +830,53 @@ describe("status command", () => {
       project: "my-app",
     });
   });
+
+  it("--quiet outputs one session name per line with no other output", async () => {
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({ id: "app-1", projectId: "my-app", branch: "feat/a" }),
+      makeSession({ id: "app-2", projectId: "my-app", branch: "feat/b" }),
+    ]);
+    mockGit.mockResolvedValue(null);
+
+    await program.parseAsync(["node", "test", "status", "--quiet"]);
+
+    const calls = consoleSpy.mock.calls.map((c) => c[0]);
+    expect(calls).toEqual(["app-1", "app-2"]);
+  });
+
+  it("--quiet outputs nothing when there are no sessions", async () => {
+    mockSessionManager.list.mockResolvedValue([]);
+    mockGit.mockResolvedValue(null);
+
+    await program.parseAsync(["node", "test", "status", "--quiet"]);
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it("--quiet works with -q shorthand", async () => {
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({ id: "app-42", projectId: "my-app", branch: "feat/q" }),
+    ]);
+    mockGit.mockResolvedValue(null);
+
+    await program.parseAsync(["node", "test", "status", "-q"]);
+
+    const calls = consoleSpy.mock.calls.map((c) => c[0]);
+    expect(calls).toEqual(["app-42"]);
+  });
+
+  it("--quiet does not print banner, header, or table", async () => {
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({ id: "app-1", projectId: "my-app", branch: "feat/a" }),
+    ]);
+    mockGit.mockResolvedValue(null);
+
+    await program.parseAsync(["node", "test", "status", "--quiet"]);
+
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).not.toContain("AGENT ORCHESTRATOR STATUS");
+    expect(output).not.toContain("Session");
+    expect(output).not.toContain("Branch");
+    expect(output).not.toContain("active session");
+  });
 });

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -210,11 +210,16 @@ export function registerStatus(program: Command): void {
     .description("Show all sessions with branch, activity, PR, and CI status")
     .option("-p, --project <id>", "Filter by project ID")
     .option("--json", "Output as JSON")
-    .action(async (opts: { project?: string; json?: boolean }) => {
+    .option("-q, --quiet", "Output only session names, one per line (for scripting)")
+    .action(async (opts: { project?: string; json?: boolean; quiet?: boolean }) => {
       let config: ReturnType<typeof loadConfig>;
       try {
         config = loadConfig();
       } catch {
+        if (opts.quiet) {
+          // In quiet mode, no config means no sessions — output nothing
+          return;
+        }
         console.log(chalk.yellow("No config found. Run `ao init` first."));
         console.log(chalk.dim("Falling back to session discovery...\n"));
         await showFallbackStatus();
@@ -229,6 +234,13 @@ export function registerStatus(program: Command): void {
       // Use session manager to list sessions (metadata-based, not tmux-based)
       const sm = await getSessionManager(config);
       const sessions = await sm.list(opts.project);
+
+      if (opts.quiet) {
+        for (const s of sessions) {
+          console.log(s.id);
+        }
+        return;
+      }
 
       if (!opts.json) {
         console.log(banner("AGENT ORCHESTRATOR STATUS"));


### PR DESCRIPTION
## Summary

- Adds `-q`/`--quiet` flag to `ao status` that outputs only session names, one per line
- No headers, no table formatting, no banner — just the bare session IDs
- Useful for scripting: `ao status --quiet | wc -l`, `ao status -q | xargs -I{} ao send {} "message"`
- When no config exists and `--quiet` is passed, exits silently with no output (instead of the "no config" warning)

Closes #16

## Test plan
- [x] `--quiet` outputs one session name per line with no other output
- [x] `--quiet` outputs nothing when there are no sessions
- [x] `-q` shorthand works identically to `--quiet`
- [x] `--quiet` does not print banner, header, or table
- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (warnings only, no errors)
- [x] All status tests pass (25/25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)