### PR TITLE
fix(test): isolate ao-doctor test PATH to prevent environment-dependent failures

### DIFF
--- a/packages/cli/__tests__/scripts/doctor-script.test.ts
+++ b/packages/cli/__tests__/scripts/doctor-script.test.ts
@@ -14,6 +14,20 @@ import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+/**
+ * Build a PATH string that places `binDir` first and strips any system
+ * directories that contain an `ao` binary.  This prevents a globally-installed
+ * `ao` (e.g. /usr/local/bin/ao) from masking the absence of the launcher
+ * inside the fake bin directory during tests that exercise the launcher-fix
+ * code path.
+ */
+function buildIsolatedPath(binDir: string): string {
+  const systemPaths = (process.env["PATH"] ?? "")
+    .split(":")
+    .filter((p) => p.length > 0 && !existsSync(join(p, "ao")));
+  return [binDir, ...systemPaths].join(":");
+}
+
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
 const scriptPath = join(repoRoot, "scripts", "ao-doctor.sh");
 
@@ -149,7 +163,7 @@ describe("scripts/ao-doctor.sh", () => {
     const result = spawnSync("bash", [scriptPath, "--fix"], {
       env: {
         ...process.env,
-        PATH: `${binDir}:${process.env.PATH || ""}`,
+        PATH: buildIsolatedPath(binDir),
         AO_REPO_ROOT: fakeRepo,
         AO_CONFIG_PATH: configPath,
         AO_DOCTOR_TMP_ROOT: tmpRoot,


### PR DESCRIPTION
## Summary

- Fixes a flaky test in `packages/cli/__tests__/scripts/doctor-script.test.ts` that failed on environments where `ao` is globally installed (e.g. `/usr/local/bin/ao`)
- Adds a `buildIsolatedPath()` helper that strips PATH entries containing an `ao` binary before prepending the fake `binDir`, ensuring the "launcher absent" code path in `ao-doctor.sh` is exercised correctly
- The test now passes deterministically regardless of whether `ao` is installed system-wide

## Background

Issue #119 tracks making the agent summary `summaryIsFallback` metadata explicit so the dashboard does not rely on heuristics like `looksLikePromptExcerpt()`. That refactor is already complete in `main`:
- `AgentSessionInfo.summaryIsFallback?: boolean` added to core types
- `extractSummary()` in `agent-claude-code` returns `{ summary, isFallback }`
- `getSessionInfo()` in both `agent-claude-code` and `agent-codex` sets `summaryIsFallback`
- `format.ts` uses `summaryIsFallback` in `getSessionTitle()` (the old `looksLikePromptExcerpt()` heuristic is gone)
- `serialize.ts` propagates `summaryIsFallback` through `enrichSessionAgentSummary()`

This PR resolves the remaining pre-existing test failure that was blocking clean CI runs.

## Root Cause

The failing test removed `ao` from the fake `binDir` but kept `process.env.PATH` intact. On machines with `ao` installed at `/usr/local/bin/ao`, `command -v ao` in `ao-doctor.sh` still found the system binary, so the launcher-fix branch was never entered and `npm.log` was never created causing an `ENOENT` when the test tried to read it.

## Test plan

- [x] `pnpm --filter @composio/ao-cli test` all 227 tests pass (previously 1 failed)
- [x] `pnpm build` builds cleanly
- [x] `pnpm typecheck` no type errors
- [x] `pnpm lint` no new errors

Closes #119

:robot: Generated with [Claude Code](https://claude.com/claude-code)