### PR TITLE
feat(cli): add --quiet/-q flag to ao status for scriptable output

### DIFF
--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -798,6 +798,77 @@ describe("status command", () => {
     expect(output).toContain("1 active session across 2 projects · 2 orchestrators");
   });
 
+  describe("--quiet flag", () => {
+    it("outputs only session names, one per line", async () => {
+      mockSessionManager.list.mockResolvedValue([
+        makeSession({ id: "app-1", projectId: "my-app", branch: "feat/a" }),
+        makeSession({ id: "app-2", projectId: "my-app", branch: "feat/b" }),
+        makeSession({ id: "app-3", projectId: "my-app", branch: "feat/c" }),
+      ]);
+      mockGit.mockResolvedValue(null);
+
+      await program.parseAsync(["node", "test", "status", "--quiet"]);
+
+      const lines = consoleSpy.mock.calls.map((c) => c[0] as string);
+      expect(lines).toEqual(["app-1", "app-2", "app-3"]);
+    });
+
+    it("outputs nothing when there are no sessions", async () => {
+      mockSessionManager.list.mockResolvedValue([]);
+      mockGit.mockResolvedValue(null);
+
+      await program.parseAsync(["node", "test", "status", "--quiet"]);
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not print banner or table headers in quiet mode", async () => {
+      mockSessionManager.list.mockResolvedValue([
+        makeSession({ id: "app-1", projectId: "my-app", branch: "feat/a" }),
+      ]);
+      mockGit.mockResolvedValue(null);
+
+      await program.parseAsync(["node", "test", "status", "--quiet"]);
+
+      const output = consoleSpy.mock.calls.map((c) => c[0] as string).join("\n");
+      expect(output).not.toContain("AGENT ORCHESTRATOR STATUS");
+      expect(output).not.toContain("Session");
+      expect(output).not.toContain("Branch");
+      expect(output).toBe("app-1");
+    });
+
+    it("includes orchestrators in quiet output", async () => {
+      mockSessionManager.list.mockResolvedValue([
+        makeSession({
+          id: "app-orchestrator",
+          projectId: "my-app",
+          metadata: { role: "orchestrator" },
+        }),
+        makeSession({ id: "app-1", projectId: "my-app", branch: "feat/a" }),
+      ]);
+      mockGit.mockResolvedValue(null);
+
+      await program.parseAsync(["node", "test", "status", "--quiet"]);
+
+      const lines = consoleSpy.mock.calls.map((c) => c[0] as string);
+      expect(lines).toContain("app-orchestrator");
+      expect(lines).toContain("app-1");
+      expect(lines).toHaveLength(2);
+    });
+
+    it("supports -q short form", async () => {
+      mockSessionManager.list.mockResolvedValue([
+        makeSession({ id: "ao-1-fix-json", projectId: "my-app", branch: "fix/json" }),
+      ]);
+      mockGit.mockResolvedValue(null);
+
+      await program.parseAsync(["node", "test", "status", "-q"]);
+
+      const lines = consoleSpy.mock.calls.map((c) => c[0] as string);
+      expect(lines).toEqual(["ao-1-fix-json"]);
+    });
+  });
+
   it("includes orchestrators in JSON output with explicit roles", async () => {
     mockSessionManager.list.mockResolvedValue([
       makeSession({

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -210,11 +210,16 @@ export function registerStatus(program: Command): void {
     .description("Show all sessions with branch, activity, PR, and CI status")
     .option("-p, --project <id>", "Filter by project ID")
     .option("--json", "Output as JSON")
-    .action(async (opts: { project?: string; json?: boolean }) => {
+    .option("-q, --quiet", "Output only session names, one per line (for scripting)")
+    .action(async (opts: { project?: string; json?: boolean; quiet?: boolean }) => {
       let config: ReturnType<typeof loadConfig>;
       try {
         config = loadConfig();
       } catch {
+        if (opts.quiet) {
+          await showFallbackQuiet();
+          return;
+        }
         console.log(chalk.yellow("No config found. Run `ao init` first."));
         console.log(chalk.dim("Falling back to session discovery...\n"));
         await showFallbackStatus();
@@ -229,6 +234,14 @@ export function registerStatus(program: Command): void {
       // Use session manager to list sessions (metadata-based, not tmux-based)
       const sm = await getSessionManager(config);
       const sessions = await sm.list(opts.project);
+
+      // Quiet mode: just print session names, one per line
+      if (opts.quiet) {
+        for (const s of sessions) {
+          console.log(s.id);
+        }
+        return;
+      }
 
       if (!opts.json) {
         console.log(banner("AGENT ORCHESTRATOR STATUS"));
@@ -362,6 +375,13 @@ export function registerStatus(program: Command): void {
         console.log();
       }
     });
+}
+
+async function showFallbackQuiet(): Promise<void> {
+  const allTmux = await getTmuxSessions();
+  for (const session of allTmux.sort()) {
+    console.log(session);
+  }
 }
 
 async function showFallbackStatus(): Promise<void> {


### PR DESCRIPTION
## Summary

- Adds `-q` / `--quiet` flag to `ao status` that outputs only session names, one per line
- Skips banner, table headers, and all rich formatting in quiet mode — ideal for scripting and piping
- Gracefully handles the no-config fallback path: prints bare tmux session names without banner or introspection

## Example

```
$ ao status --quiet
ao-1-fix-json
ao-2-add-license
ao-3-readme-badges

$ ao status -q | wc -l
3
```

## Test plan

- [x] `--quiet flag > outputs only session names, one per line`
- [x] `--quiet flag > outputs nothing when there are no sessions`
- [x] `--quiet flag > does not print banner or table headers in quiet mode`
- [x] `--quiet flag > includes orchestrators in quiet output`
- [x] `--quiet flag > supports -q short form`
- [x] All 26 status command tests pass

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)