### PR TITLE
feat(status): add session age display and --quiet flag

### DIFF
--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -830,4 +830,90 @@ describe("status command", () => {
       project: "my-app",
     });
   });
+
+  it("includes age field in JSON output computed from session createdAt", async () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({
+        id: "app-1",
+        projectId: "my-app",
+        branch: "feat/age-test",
+        createdAt: twoHoursAgo,
+      }),
+    ]);
+    mockGit.mockResolvedValue(null);
+
+    await program.parseAsync(["node", "test", "status", "--json"]);
+
+    const jsonCalls = consoleSpy.mock.calls.map((c) => c[0]).join("");
+    const parsed = JSON.parse(jsonCalls);
+    expect(parsed[0].age).toBe("2h ago");
+  });
+
+  it("shows session age in table output", async () => {
+    const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000);
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({
+        id: "app-1",
+        projectId: "my-app",
+        branch: "feat/age-display",
+        createdAt: thirtyMinutesAgo,
+      }),
+    ]);
+    mockGit.mockResolvedValue(null);
+    mockTmux.mockResolvedValue(null);
+
+    await program.parseAsync(["node", "test", "status"]);
+
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("30m ago");
+  });
+
+  it("--quiet outputs only session names, one per line", async () => {
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({ id: "app-1", projectId: "my-app" }),
+      makeSession({ id: "app-2", projectId: "my-app" }),
+      makeSession({ id: "app-3", projectId: "my-app" }),
+    ]);
+
+    await program.parseAsync(["node", "test", "status", "--quiet"]);
+
+    const lines = consoleSpy.mock.calls.map((c) => c[0]);
+    expect(lines).toEqual(["app-1", "app-2", "app-3"]);
+  });
+
+  it("--quiet outputs nothing when there are no sessions", async () => {
+    mockSessionManager.list.mockResolvedValue([]);
+
+    await program.parseAsync(["node", "test", "status", "--quiet"]);
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it("--quiet outputs sessions sorted alphabetically", async () => {
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({ id: "app-3", projectId: "my-app" }),
+      makeSession({ id: "app-1", projectId: "my-app" }),
+      makeSession({ id: "app-2", projectId: "my-app" }),
+    ]);
+
+    await program.parseAsync(["node", "test", "status", "--quiet"]);
+
+    const lines = consoleSpy.mock.calls.map((c) => c[0]);
+    expect(lines).toEqual(["app-1", "app-2", "app-3"]);
+  });
+
+  it("--quiet skips banner, headers, and footers", async () => {
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({ id: "app-1", projectId: "my-app" }),
+    ]);
+
+    await program.parseAsync(["node", "test", "status", "--quiet"]);
+
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).not.toContain("AGENT ORCHESTRATOR STATUS");
+    expect(output).not.toContain("Session");
+    expect(output).not.toContain("Branch");
+    expect(output).toBe("app-1");
+  });
 });

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -37,6 +37,8 @@ interface SessionInfo {
   prNumber: number | null;
   issue: string | null;
   lastActivity: string;
+  /** Human-readable session age (time since session was created/started) */
+  age: string;
   project: string | null;
   ciStatus: CIStatus | null;
   reviewDecision: ReviewDecision | null;
@@ -118,6 +120,9 @@ async function gatherSessionInfo(
     }
   }
 
+  // Calculate session age from createdAt timestamp
+  const age = formatAge(session.createdAt.getTime());
+
   return {
     name: session.id,
     role: isOrchestratorSession(session) ? "orchestrator" : "worker",
@@ -129,6 +134,7 @@ async function gatherSessionInfo(
     prNumber,
     issue,
     lastActivity,
+    age,
     project: session.projectId,
     ciStatus,
     reviewDecision,
@@ -181,7 +187,7 @@ function printSessionRow(info: SessionInfo): void {
       COL.threads,
     ) +
     padCol(activityIcon(info.activity), COL.activity) +
-    chalk.dim(info.lastActivity);
+    chalk.dim(info.age);
 
   console.log(`  ${row}`);
 
@@ -210,7 +216,8 @@ export function registerStatus(program: Command): void {
     .description("Show all sessions with branch, activity, PR, and CI status")
     .option("-p, --project <id>", "Filter by project ID")
     .option("--json", "Output as JSON")
-    .action(async (opts: { project?: string; json?: boolean }) => {
+    .option("-q, --quiet", "Output only session names, one per line (for scripting)")
+    .action(async (opts: { project?: string; json?: boolean; quiet?: boolean }) => {
       let config: ReturnType<typeof loadConfig>;
       try {
         config = loadConfig();
@@ -229,6 +236,14 @@ export function registerStatus(program: Command): void {
       // Use session manager to list sessions (metadata-based, not tmux-based)
       const sm = await getSessionManager(config);
       const sessions = await sm.list(opts.project);
+
+      // --quiet mode: just print session names, one per line (no headers, no table)
+      if (opts.quiet) {
+        for (const s of sessions.sort((a, b) => a.id.localeCompare(b.id))) {
+          console.log(s.id);
+        }
+        return;
+      }
 
       if (!opts.json) {
         console.log(banner("AGENT ORCHESTRATOR STATUS"));


### PR DESCRIPTION
## Summary

- **Session Age Display (#7)**: The `Age` column in `ao status` now shows how long a session has been running (e.g. `5m ago`, `2h ago`, `1d ago`), computed from `session.createdAt`. Previously it showed the last tmux activity timestamp.
- **Quiet Flag (#16)**: Added `-q/--quiet` flag to `ao status` that outputs only session names, one per line — no banners, headers, or table formatting. Useful for scripting: `ao status --quiet | wc -l`.

## Changes

- `packages/cli/src/commands/status.ts`:
  - Added `age: string` field to `SessionInfo` interface
  - Computed `age` from `session.createdAt.getTime()` via the existing `formatAge()` helper
  - The `Age` column in the table now renders `info.age` (session creation age) instead of `info.lastActivity`
  - Added `-q, --quiet` option to the `status` command
  - When `--quiet` is passed, sessions are printed as plain names sorted alphabetically, then the command returns immediately
- `packages/cli/__tests__/commands/status.test.ts`:
  - Added test: `age` field in JSON output computed from `createdAt`
  - Added test: session age appears in table output
  - Added tests: `--quiet` outputs names only, handles empty list, sorts alphabetically, skips all decorative output

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm typecheck` — passes
- [x] `pnpm eslint` — no new warnings
- [x] All 27 status tests pass
- [x] `ao status --quiet | wc -l` counts sessions correctly
- [x] `ao status` shows `2h ago` style age in the Age column

Closes #7
Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)