### PR TITLE
feat: add session age display from createdAt to ao status

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -37,6 +37,8 @@ interface SessionInfo {
   prNumber: number | null;
   issue: string | null;
   lastActivity: string;
+  /** Human-readable session age since createdAt (e.g. "5m ago", "2h ago") */
+  age: string;
   project: string | null;
   ciStatus: CIStatus | null;
   reviewDecision: ReviewDecision | null;
@@ -67,6 +69,9 @@ async function gatherSessionInfo(
   const tmuxTarget = session.runtimeHandle?.id ?? session.id;
   const activityTs = await getTmuxActivity(tmuxTarget);
   const lastActivity = activityTs ? formatAge(activityTs) : "-";
+
+  // Calculate session age from createdAt
+  const age = formatAge(session.createdAt.getTime());
 
   // Get agent's auto-generated summary via introspection
   let claudeSummary: string | null = null;
@@ -129,6 +134,7 @@ async function gatherSessionInfo(
     prNumber,
     issue,
     lastActivity,
+    age,
     project: session.projectId,
     ciStatus,
     reviewDecision,
@@ -181,7 +187,7 @@ function printSessionRow(info: SessionInfo): void {
       COL.threads,
     ) +
     padCol(activityIcon(info.activity), COL.activity) +
-    chalk.dim(info.lastActivity);
+    chalk.dim(info.age);
 
   console.log(`  ${row}`);
 


### PR DESCRIPTION
## Summary

- Adds an `age` field to `SessionInfo` computed from `session.createdAt`
- Updates the "Age" column in `ao status` table to display how long each session has been running (e.g. "5m ago", "2h ago", "1d ago") instead of last tmux activity time
- Keeps `lastActivity` (tmux activity timestamp) in the data model for other uses (orchestrator row display)

## Why

Previously the "Age" column displayed the last tmux activity timestamp rather than the session's actual age since creation. Users want to quickly see how long each session has been running, not just when it last had terminal activity.

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [x] Tests pass (pre-existing `doctor-script.test.ts` failure is unrelated to this change)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)