### PR TITLE
feat: add --quiet flag to ao status for scriptable output

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -210,11 +210,13 @@ export function registerStatus(program: Command): void {
     .description("Show all sessions with branch, activity, PR, and CI status")
     .option("-p, --project <id>", "Filter by project ID")
     .option("--json", "Output as JSON")
-    .action(async (opts: { project?: string; json?: boolean }) => {
+    .option("-q, --quiet", "Output session names only, one per line (for scripting)")
+    .action(async (opts: { project?: string; json?: boolean; quiet?: boolean }) => {
       let config: ReturnType<typeof loadConfig>;
       try {
         config = loadConfig();
       } catch {
+        if (opts.quiet) return; // Nothing to output without config
         console.log(chalk.yellow("No config found. Run `ao init` first."));
         console.log(chalk.dim("Falling back to session discovery...\n"));
         await showFallbackStatus();
@@ -229,6 +231,14 @@ export function registerStatus(program: Command): void {
       // Use session manager to list sessions (metadata-based, not tmux-based)
       const sm = await getSessionManager(config);
       const sessions = await sm.list(opts.project);
+
+      // --quiet: output only session names, one per line (for scripting/piping)
+      if (opts.quiet) {
+        for (const s of sessions) {
+          console.log(s.id);
+        }
+        return;
+      }
 
       if (!opts.json) {
         console.log(banner("AGENT ORCHESTRATOR STATUS"));


### PR DESCRIPTION
## Summary

- Adds `-q`/`--quiet` flag to `ao status`
- When `--quiet` is set, outputs only session names one per line with no headers, banner, or table formatting
- When no config is found and `--quiet` is set, exits silently (no error output)

## Example

```sh
$ ao status --quiet
ao-1-fix-json
ao-2-add-license
ao-3-readme-badges

$ ao status --quiet | wc -l
3
```

## Why

Enables scripting and piping with `ao status`. Previously users had to parse the rich table output to extract session names for use in scripts.

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [x] Tests pass (pre-existing `doctor-script.test.ts` failure is unrelated)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)