### PR TITLE
fix(doctor): auto-create missing config directories without --fix

### DIFF
--- a/packages/cli/__tests__/scripts/doctor-script.test.ts
+++ b/packages/cli/__tests__/scripts/doctor-script.test.ts
@@ -112,6 +112,44 @@ describe("scripts/ao-doctor.sh", () => {
     expect(result.stdout).toContain("Environment looks healthy");
   });
 
+  it("auto-creates missing config directories without --fix", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "ao-doctor-autofix-"));
+    const fakeRepo = createHealthyRepo(tempRoot);
+    const binDir = join(tempRoot, "bin");
+    mkdirSync(binDir, { recursive: true });
+    createHealthyPath(binDir);
+
+    const configPath = join(tempRoot, "agent-orchestrator.yaml");
+    const dataDir = join(tempRoot, "data");
+    const worktreeDir = join(tempRoot, "worktrees");
+    // Intentionally do NOT pre-create dataDir and worktreeDir
+    writeFileSync(
+      configPath,
+      [`dataDir: ${dataDir}`, `worktreeDir: ${worktreeDir}`, "projects: {}"].join("\n"),
+    );
+
+    const result = spawnSync("bash", [scriptPath], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH || ""}`,
+        AO_REPO_ROOT: fakeRepo,
+        AO_CONFIG_PATH: configPath,
+      },
+      encoding: "utf8",
+    });
+
+    const dataDirCreated = existsSync(dataDir);
+    const worktreeDirCreated = existsSync(worktreeDir);
+    rmSync(tempRoot, { recursive: true, force: true });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("FIXED");
+    expect(result.stdout).toContain("metadata directory created");
+    expect(result.stdout).toContain("worktree directory created");
+    expect(dataDirCreated).toBe(true);
+    expect(worktreeDirCreated).toBe(true);
+  });
+
   it("applies safe fixes for missing launcher, missing dirs, and stale temp files", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "ao-doctor-fix-"));
     const fakeRepo = createHealthyRepo(tempRoot);
@@ -149,7 +187,9 @@ describe("scripts/ao-doctor.sh", () => {
     const result = spawnSync("bash", [scriptPath, "--fix"], {
       env: {
         ...process.env,
-        PATH: `${binDir}:${process.env.PATH || ""}`,
+        // Use a restricted PATH so the real system 'ao' (e.g. /usr/local/bin/ao)
+        // is not visible — only our fake binaries in binDir are found.
+        PATH: `${binDir}:/bin:/usr/bin`,
         AO_REPO_ROOT: fakeRepo,
         AO_CONFIG_PATH: configPath,
         AO_DOCTOR_TMP_ROOT: tmpRoot,

--- a/scripts/ao-doctor.sh
+++ b/scripts/ao-doctor.sh
@@ -113,12 +113,13 @@ ensure_dir() {
   local dir_path="$1"
   local label="$2"
   local fix_hint="$3"
+  local auto_create="${4:-false}"
   if [ -d "$dir_path" ]; then
     pass "$label exists at $dir_path"
     return 0
   fi
 
-  if [ "$FIX_MODE" = true ]; then
+  if [ "$FIX_MODE" = true ] || [ "$auto_create" = true ]; then
     if mkdir -p "$dir_path"; then
       fixed "$label created at $dir_path"
       return 0
@@ -288,8 +289,8 @@ check_config_dirs() {
   data_dir="$(expand_home "$data_dir")"
   worktree_dir="$(expand_home "$worktree_dir")"
 
-  ensure_dir "$data_dir" "metadata directory" "mkdir -p $data_dir"
-  ensure_dir "$worktree_dir" "worktree directory" "mkdir -p $worktree_dir"
+  ensure_dir "$data_dir" "metadata directory" "mkdir -p $data_dir" true
+  ensure_dir "$worktree_dir" "worktree directory" "mkdir -p $worktree_dir" true
 }
 
 check_stale_temp_files() {


### PR DESCRIPTION
## Summary

- Modified `ensure_dir` in `ao-doctor.sh` to accept an optional `auto_create` parameter that triggers directory creation without needing `--fix` mode
- Updated `check_config_dirs` to always auto-create essential runtime directories (`~/.agent-orchestrator` and `~/.worktrees`) when missing, reporting `FIXED` instead of `WARN`
- Added a new test verifying that `ao doctor` (without `--fix`) auto-creates missing config directories
- Fixed a pre-existing test failure where the real system `ao` binary leaked through the inherited PATH, causing the "applies safe fixes" test to skip the `npm link` step — fixed by using a restricted PATH (`/bin:/usr/bin`) in that test

Closes #15

## Test plan

- [ ] `pnpm test` — all 228 tests pass including 3 doctor-script tests
- [ ] `ao doctor` with missing dirs — both are auto-created, output shows `FIXED`
- [ ] `ao doctor --fix` — unchanged behaviour for stale temp files and launcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)