### PR TITLE
refactor: extract runCmd helper into shared utils package

### DIFF
--- a/packages/cli/src/lib/shell.ts
+++ b/packages/cli/src/lib/shell.ts
@@ -1,33 +1,17 @@
-import { execFile as execFileCb } from "node:child_process";
-import { promisify } from "node:util";
+import { runCmd, tryRunCmd } from "@composio/ao-core";
 
-const execFileAsync = promisify(execFileCb);
-
-export interface ExecResult {
-  stdout: string;
-  stderr: string;
-}
+export type { RunCmdResult as ExecResult } from "@composio/ao-core";
 
 export async function exec(
   cmd: string,
   args: string[],
   options?: { cwd?: string; env?: Record<string, string> },
-): Promise<ExecResult> {
-  const { stdout, stderr } = await execFileAsync(cmd, args, {
-    cwd: options?.cwd,
-    env: options?.env ? { ...process.env, ...options.env } : undefined,
-    maxBuffer: 10 * 1024 * 1024,
-  });
-  return { stdout: stdout.trimEnd(), stderr: stderr.trimEnd() };
+): Promise<{ stdout: string; stderr: string }> {
+  return runCmd(cmd, args, options);
 }
 
 export async function execSilent(cmd: string, args: string[]): Promise<string | null> {
-  try {
-    const { stdout } = await exec(cmd, args);
-    return stdout;
-  } catch {
-    return null;
-  }
+  return tryRunCmd(cmd, args);
 }
 
 export async function tmux(...args: string[]): Promise<string | null> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,6 +95,8 @@ export {
   normalizeRetryConfig,
   readLastJsonlEntry,
 } from "./utils.js";
+export { runCmd, tryRunCmd } from "./utils/run-cmd.js";
+export type { RunCmdOptions, RunCmdResult } from "./utils/run-cmd.js";
 export {
   getWebhookHeader,
   parseWebhookJsonObject,

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -12,10 +12,9 @@
  */
 
 import { statSync, existsSync, readdirSync, writeFileSync, mkdirSync, utimesSync } from "node:fs";
-import { execFile } from "node:child_process";
 import { basename, join, resolve } from "node:path";
 import { homedir } from "node:os";
-import { promisify } from "node:util";
+import { runCmd } from "./utils/run-cmd.js";
 import {
   isIssueNotFoundError,
   isRestorable,
@@ -75,7 +74,6 @@ import { sessionFromMetadata } from "./utils/session-from-metadata.js";
 import { safeJsonParse } from "./utils/validation.js";
 import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
 
-const execFileAsync = promisify(execFile);
 const OPENCODE_DISCOVERY_TIMEOUT_MS = 2_000;
 const OPENCODE_INTERACTIVE_DISCOVERY_TIMEOUT_MS = 10_000;
 
@@ -96,7 +94,7 @@ async function deleteOpenCodeSession(sessionId: string): Promise<void> {
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
     try {
-      await execFileAsync("opencode", ["session", "delete", validatedSessionId], {
+      await runCmd("opencode", ["session", "delete", validatedSessionId], {
         timeout: 30_000,
       });
       return;
@@ -120,7 +118,7 @@ async function fetchOpenCodeSessionList(
   timeoutMs = OPENCODE_DISCOVERY_TIMEOUT_MS,
 ): Promise<OpenCodeSessionListEntry[]> {
   try {
-    const { stdout } = await execFileAsync("opencode", ["session", "list", "--format", "json"], {
+    const { stdout } = await runCmd("opencode", ["session", "list", "--format", "json"], {
       timeout: timeoutMs,
     });
     const parsed = safeJsonParse<unknown>(stdout);
@@ -230,7 +228,7 @@ function sleep(ms: number): Promise<void> {
 
 async function getTmuxForegroundCommand(sessionName: string): Promise<string | null> {
   try {
-    const { stdout } = await execFileAsync(
+    const { stdout } = await runCmd(
       "tmux",
       ["display-message", "-p", "-t", sessionName, "#{pane_current_command}"],
       { timeout: 5_000 },
@@ -629,7 +627,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
   async function listRemoteSessionNumbers(project: ProjectConfig): Promise<number[]> {
     try {
-      const { stdout } = await execFileAsync(
+      const { stdout } = await runCmd(
         "git",
         ["ls-remote", "--heads", "origin", `session/${project.sessionPrefix}-*`],
         {

--- a/packages/core/src/utils/run-cmd.ts
+++ b/packages/core/src/utils/run-cmd.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared command execution utility.
+ *
+ * Wraps Node.js execFile with consistent timeout, buffering, and error
+ * handling. Prefer this over raw child_process calls so that every
+ * `execFile` invocation in the codebase shares the same defaults.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** Default timeout for external commands (30 seconds). */
+const DEFAULT_TIMEOUT_MS = 30_000;
+/** Default max output buffer size (10 MB). */
+const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
+
+export interface RunCmdOptions {
+  /** Working directory for the subprocess. */
+  cwd?: string;
+  /** Extra environment variables merged on top of process.env. */
+  env?: Record<string, string>;
+  /**
+   * Execution timeout in milliseconds.
+   * Defaults to 30 000 ms (30 s).
+   */
+  timeout?: number;
+  /**
+   * Maximum stdout/stderr buffer size in bytes.
+   * Defaults to 10 MB.
+   */
+  maxBuffer?: number;
+}
+
+export interface RunCmdResult {
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Run an external command via execFile (no shell injection risk).
+ *
+ * Returns stdout and stderr trimmed of trailing whitespace.
+ * Throws on non-zero exit code.
+ */
+export async function runCmd(
+  cmd: string,
+  args: string[],
+  options?: RunCmdOptions,
+): Promise<RunCmdResult> {
+  const { stdout, stderr } = await execFileAsync(cmd, args, {
+    cwd: options?.cwd,
+    env: options?.env ? { ...process.env, ...options.env } : undefined,
+    timeout: options?.timeout ?? DEFAULT_TIMEOUT_MS,
+    maxBuffer: options?.maxBuffer ?? DEFAULT_MAX_BUFFER,
+  });
+  return { stdout: stdout.trimEnd(), stderr: stderr.trimEnd() };
+}
+
+/**
+ * Run a command, returning stdout or `null` on any error (non-zero
+ * exit, timeout, ENOENT, etc.).
+ */
+export async function tryRunCmd(
+  cmd: string,
+  args: string[],
+  options?: RunCmdOptions,
+): Promise<string | null> {
+  try {
+    const { stdout } = await runCmd(cmd, args, options);
+    return stdout;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Creates `packages/core/src/utils/run-cmd.ts` with shared `runCmd` and `tryRunCmd` helpers
- Migrates `packages/core/src/session-manager.ts` (4 call-sites) away from local `promisify(execFile)` to the shared helper
- Migrates `packages/cli/src/lib/shell.ts` — `exec()` and `execSilent()` now delegate to `runCmd`/`tryRunCmd` from `@composio/ao-core`
- Exports `runCmd`, `tryRunCmd`, `RunCmdOptions`, `RunCmdResult` from `@composio/ao-core`

Closes #17

## Why

The exec pattern for shelling out was duplicated across `session-manager.ts` and `cli/lib/shell.ts`. This refactor gives both a single, well-documented source of truth with consistent defaults (30s timeout, 10MB buffer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)