### PR TITLE
fix(doctor): auto-create missing directories without --fix flag

### DIFF
--- a/packages/cli/__tests__/scripts/doctor-script.test.ts
+++ b/packages/cli/__tests__/scripts/doctor-script.test.ts
@@ -112,6 +112,44 @@ describe("scripts/ao-doctor.sh", () => {
     expect(result.stdout).toContain("Environment looks healthy");
   });
 
+  it("auto-creates missing config directories without --fix and reports FIXED", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "ao-doctor-autofix-"));
+    const fakeRepo = createHealthyRepo(tempRoot);
+    const binDir = join(tempRoot, "bin");
+    mkdirSync(binDir, { recursive: true });
+    createHealthyPath(binDir);
+
+    const configPath = join(tempRoot, "agent-orchestrator.yaml");
+    const dataDir = join(tempRoot, "data");
+    const worktreeDir = join(tempRoot, "worktrees");
+    // intentionally do NOT create dataDir or worktreeDir
+    writeFileSync(
+      configPath,
+      [`dataDir: ${dataDir}`, `worktreeDir: ${worktreeDir}`, "projects: {}"].join("\n"),
+    );
+
+    const result = spawnSync("bash", [scriptPath], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH || ""}`,
+        AO_REPO_ROOT: fakeRepo,
+        AO_CONFIG_PATH: configPath,
+      },
+      encoding: "utf8",
+    });
+
+    const dataDirExists = existsSync(dataDir);
+    const worktreeDirExists = existsSync(worktreeDir);
+    rmSync(tempRoot, { recursive: true, force: true });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("FIXED");
+    expect(result.stdout).toContain("metadata directory created");
+    expect(result.stdout).toContain("worktree directory created");
+    expect(dataDirExists).toBe(true);
+    expect(worktreeDirExists).toBe(true);
+  });
+
   it("applies safe fixes for missing launcher, missing dirs, and stale temp files", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "ao-doctor-fix-"));
     const fakeRepo = createHealthyRepo(tempRoot);
@@ -119,6 +157,13 @@ describe("scripts/ao-doctor.sh", () => {
     mkdirSync(binDir, { recursive: true });
     createHealthyPath(binDir);
     rmSync(join(binDir, "ao"), { force: true });
+
+    // Exclude any system PATH directories that contain a real 'ao' binary so that
+    // check_launcher correctly detects it as missing and triggers the npm-link fix.
+    const cleanedSystemPath = (process.env.PATH || "")
+      .split(":")
+      .filter((dir) => !existsSync(join(dir, "ao")))
+      .join(":");
 
     const npmLog = join(tempRoot, "npm.log");
     createFakeBinary(
@@ -149,7 +194,7 @@ describe("scripts/ao-doctor.sh", () => {
     const result = spawnSync("bash", [scriptPath, "--fix"], {
       env: {
         ...process.env,
-        PATH: `${binDir}:${process.env.PATH || ""}`,
+        PATH: `${binDir}:${cleanedSystemPath}`,
         AO_REPO_ROOT: fakeRepo,
         AO_CONFIG_PATH: configPath,
         AO_DOCTOR_TMP_ROOT: tmpRoot,

--- a/scripts/ao-doctor.sh
+++ b/scripts/ao-doctor.sh
@@ -118,16 +118,12 @@ ensure_dir() {
     return 0
   fi
 
-  if [ "$FIX_MODE" = true ]; then
-    if mkdir -p "$dir_path"; then
-      fixed "$label created at $dir_path"
-      return 0
-    fi
-    fail "$label could not be created at $dir_path. Fix: $fix_hint"
-    return 1
+  if mkdir -p "$dir_path"; then
+    fixed "$label created at $dir_path"
+    return 0
   fi
-
-  warn "$label is missing at $dir_path. Fix: $fix_hint"
+  fail "$label could not be created at $dir_path. Fix: $fix_hint"
+  return 1
 }
 
 check_command() {


### PR DESCRIPTION
## Summary

Fixes #15

- `ao doctor` now automatically creates missing `~/.agent-orchestrator` and `~/.worktrees` directories without requiring the `--fix` flag
- Reports `FIXED` instead of `WARN` when directories are auto-created
- The `--fix` flag remains useful for other fixes (launcher link, stale temp files)

## Changes

- **`scripts/ao-doctor.sh`**: Simplified `ensure_dir` to always attempt `mkdir -p` for missing directories, removing the `FIX_MODE` guard. Creating support directories is always safe so there's no reason to require an explicit opt-in.
- **`packages/cli/__tests__/scripts/doctor-script.test.ts`**: Added a new test verifying auto-creation without `--fix`. Also fixed a pre-existing test flakiness where the test assumed `ao` wasn't in the system `PATH`, causing failures in environments where `ao` is already globally installed.

## Test plan
- [ ] `ao doctor` auto-creates missing directories and reports `FIXED`
- [ ] `ao doctor --fix` still works for launcher and stale temp file fixes
- [ ] All existing tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)